### PR TITLE
Fix "TypeError: Cannot read property 'type' of null"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ module.exports = function({ Plugin, types: t, template }) {
                 lastStatement &&
                 arrowBody.type === 'BlockStatement' &&
                 lastStatement.type === 'ReturnStatement' &&
-                lastStatement.argument.type === 'JSXElement';
+                lastStatement.argument && lastStatement.argument.type === 'JSXElement';
             const isExportDefaultOrVariable = ['ExportDefaultDeclaration', 'VariableDeclarator'].includes(path.parentPath.type)
             if (!(isJSXElement || isEmbeddedReturn)) return;
             if (!isExportDefaultOrVariable) return;


### PR DESCRIPTION
Fixes an error I had when running my React Native app on my local device. 

Error did not happen when running on the simulator

Error it fixes:

```
error: bundling failed: TypeError: Cannot read property 'type' of null
    at /Users/jordy/Projects/my-app/node_modules/babel-plugin-functional-hmr/lib/index.js:95:40
    at NodePath._call (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:40:17)
    at NodePath.visit (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:88:12)
    at TraversalContext.visitQueue (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/context.js:118:16)
    at TraversalContext.visitSingle (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/context.js:90:19)
    at TraversalContext.visit (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/context.js:146:19)
    at Function.traverse.node (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/index.js:94:17)
    at NodePath.visit (/Users/jordy/Projects/my-app/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:95:18)
```